### PR TITLE
222 refactorfrontback댓글목록조회api

### DIFF
--- a/front/js/post/comments.js
+++ b/front/js/post/comments.js
@@ -11,7 +11,7 @@ const submitCommentButton = document.getElementById('submit-comment');
 const commentContentInput = document.getElementById('comment-content');
 const commentList = document.getElementById('comment-list');
 
-/** 1. 댓글을 불러오는 함수 **/
+/** 1. 댓글 목록 조회 API **/
 async function fetchComments() {
   try {
     const response = await fetch(`${API_BASE_URL}/posts/${postId}/comments`, {
@@ -42,9 +42,10 @@ function renderComments(comments) {
   }
 }
 
+
+
 /** 3. 댓글 리스트에 추가하는 함수 **/
 async function addCommentToList(comment) {
-  // const data = await fetchLD(comment.id);
   const commentItem = document.createElement('li');
   commentItem.innerHTML = `
     <div class="comment-header">
@@ -52,42 +53,86 @@ async function addCommentToList(comment) {
       <div class="comment-like-btn-count">
         <button class="comment-like-btn" data-comment-id="${comment.id}" onclick="clickLikeComment(${comment.id})">👍</button>
         <span class="comment-like-count"> ${comment.likes || 0} </span>
-       </div>
+      </div>
       <div class="comment-dislike-btn-count">
         <button class="comment-dislike-btn" data-comment-id="${comment.id}" onclick="clickDislikeComment(${comment.id})">👎</button>
         <span class="comment-dislike-count"> ${comment.dislikes || 0} </span>
       </div>             
     </div>
     <p>${comment.content}</p>
-    <button class="recomment-btn" data-comment-id="${comment.id}">대댓글 작성</button>
-    <div class="recomment-input" style="display: none;">
-      <textarea placeholder="대댓글을 입력하세요..." rows="2"></textarea>
-      <button class="submit-recomment">작성</button>
-    </div>  
+    <button class="recomment-btn" data-comment-id="${comment.id}" onclick="fetchRecomments(${comment.id})">대댓글 (${comment.recommentsCount})</button>
+    <div class="recomment-list" id="recomment-list-${comment.id}" style="display: none;"></div>  
   `;
 
-  // 3-1. 대댓글이 있는 경우 랜더링
-  if (comment.recomments && comment.recomments.length > 0) {
-    const recommentsList = document.createElement('ul');
-    recommentsList.style.listStyleType = 'none'; // 기본 리스트 스타일 제거
-    recommentsList.style.paddingLeft = '20px'; // 들여쓰기
-
-    comment.recomments.forEach((recomment) => {
-      const recommentItem = document.createElement('li');
-      recommentItem.innerHTML = `
-                      <p>${recomment.nickname}
-                      | 작성일: ${elapsedTime(recomment.createdAt)}
-                      | 좋아요: ${recomment.likes}
-                      | 싫어요: ${recomment.dislikes}</p>
-                      <p>${recomment.content}</p>
-                  `;
-      recommentsList.appendChild(recommentItem);
-    });
-    commentItem.appendChild(recommentsList);
-  }
-  // 3-2. 이어서
   commentList.appendChild(commentItem);
 }
+
+/** 4. 대댓글을 불러오는 함수 **/
+async function fetchRecomments(commentId) {
+  const recommentList = document.getElementById(`recomment-list-${commentId}`);
+  if (recommentList.style.display === 'block') {
+    recommentList.style.display = 'none'; // 이미 보이는 경우 숨김
+    return;
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/comments/${commentId}/recomments`, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      },
+    });
+    console.log("🚀 ~ fetchRecomments ~ response:", response)
+
+    if (!response.ok) throw new Error('대댓글을 불러오는 데 실패했습니다.');
+
+    const result = await response.json();
+    renderRecomments(commentId, result.data, recommentList);
+    recommentList.style.display = 'block'; // 대댓글 목록 보이기
+  } catch (error) {
+    console.error(error);
+    alert('대댓글을 불러오는 중 오류가 발생했습니다.');
+  }
+}
+
+/** 5. 대댓글 랜더링 함수 **/
+function renderRecomments(commentId, recomments, recommentList) {
+  console.log("🚀 ~ renderRecomments ~ recomments:", recomments)
+  recommentList.innerHTML = ''; // 기존 대댓글 초기화
+  if (recomments.length > 0) {
+    recomments.forEach((recomment) => {
+      const recommentItem = document.createElement('li');
+      recommentItem.innerHTML = `
+      <div class="comment-header">
+        <span>${recomment.nickname} | 작성일: ${elapsedTime(recomment.createdAt)} </span> 
+        <div class="comment-like-btn-count">
+          <button class="comment-dislike-btn" data-comment-id="${recomment.id}" onclick="clickLikeComment(${recomment.id})">👍</button>
+          <span class="recomment-like-count">${recomment.likes || 0}</span>
+        </div>
+        <div class="comment-dislike-btn-count">
+          <button class="comment-dislike-btn" data-comment-id="${recomment.id}" onclick="clickDislikeComment(${recomment.id})">👎</button>
+          <span class="recomment-dislike-count">${recomment.dislikes || 0}</span>
+        </div>
+      </div>
+      <p>${recomment.content}</p>
+      `;
+      recommentList.appendChild(recommentItem);
+    });
+  } else {
+    recommentList.innerHTML = '<p>대댓글이 없습니다.</p>';
+  }
+
+  // 대댓글 작성 버튼과 입력 공간 추가
+  const recommentInputContainer = document.createElement('div');
+  recommentInputContainer.innerHTML = `
+    <button class="recomment-btn" onclick="toggleRecommentInput(${commentId})">대댓글 작성</button>
+    <div class="recomment-input" id="recomment-input-${commentId}" style="display: none;">
+      <textarea placeholder="대댓글을 입력하세요..." rows="2"></textarea>
+      <button class="submit-recomment" onclick="addRecomment(${commentId})">작성</button>
+    </div>
+  `;
+recommentList.appendChild(recommentInputContainer);
+}
+
 
 /** 4. 나의 댓글 좋아요/싫어요 여부 조회 **/
 async function fetchLD(commentId) {
@@ -246,6 +291,7 @@ submitCommentButton.addEventListener('click', () => {
     alert('댓글 내용을 입력하세요.');
   }
 });
+
 // 2. [대댓글] 버튼 클릭 시 대댓글 입력 UI 토글
 commentList.addEventListener('click', (event) => {
   if (event.target.classList.contains('recomment-btn')) {
@@ -254,6 +300,7 @@ commentList.addEventListener('click', (event) => {
       recommentInput.style.display === 'none' ? 'block' : 'none';
   }
 });
+
 // 3. [대댓글 작성] 버튼 클릭 시 API 호출
 commentList.addEventListener('click', async (event) => {
   if (event.target.classList.contains('submit-recomment')) {
@@ -280,3 +327,4 @@ if (postId) {
 /** 전역변수 선언 **/
 window.clickLikeComment = clickLikeComment;
 window.clickDislikeComment = clickDislikeComment;
+window.fetchRecomments = fetchRecomments;

--- a/front/js/post/comments.js
+++ b/front/js/post/comments.js
@@ -23,11 +23,13 @@ async function fetchComments() {
     if (!response.ok) throw new Error('댓글을 불러오는 데 실패했습니다.');
 
     const result = await response.json();
+    console.log("🚀 ~ fetchComments ~ result.data:", result.data)
     renderComments(result.data);
   } catch (error) {
     console.error(error);
     alert('댓글을 불러오는 중 오류가 발생했습니다.');
   }
+    
 }
 
 /** 2. 댓글 랜더링 함수 **/
@@ -42,10 +44,9 @@ function renderComments(comments) {
   }
 }
 
-
-
 /** 3. 댓글 리스트에 추가하는 함수 **/
 async function addCommentToList(comment) {
+  console.log("🚀 ~ addCommentToList ~ comment:", comment)
   const commentItem = document.createElement('li');
   commentItem.innerHTML = `
     <div class="comment-header">
@@ -98,6 +99,7 @@ async function fetchRecomments(commentId) {
 function renderRecomments(commentId, recomments, recommentList) {
   console.log("🚀 ~ renderRecomments ~ recomments:", recomments)
   recommentList.innerHTML = ''; // 기존 대댓글 초기화
+  recommentList.style.paddingLeft = '20px'; // 들여쓰기
   if (recomments.length > 0) {
     recomments.forEach((recomment) => {
       const recommentItem = document.createElement('li');
@@ -296,8 +298,12 @@ submitCommentButton.addEventListener('click', () => {
 commentList.addEventListener('click', (event) => {
   if (event.target.classList.contains('recomment-btn')) {
     const recommentInput = event.target.nextElementSibling;
-    recommentInput.style.display =
-      recommentInput.style.display === 'none' ? 'block' : 'none';
+
+    // 대댓글 입력 UI가 있는지 확인
+    if (recommentInput && recommentInput.classList.contains('recomment-input')) {
+      recommentInput.style.display = 
+        recommentInput.style.display === 'none' || recommentInput.style.display === '' ? 'block' : 'none';
+    }
   }
 });
 

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -59,7 +59,7 @@ export class CommentController {
   @ApiOperation({ summary: '2. 댓글 목록 조회 API' })
   @Get()
   async findAll(@Param('postId', ParseIntPipe) postId: number) {
-    const data = await this.commentService.findCommentsByPostId(postId);
+    const data = await this.commentService.findCommentsById(postId);
 
     return {
       status: HttpStatus.OK,
@@ -158,7 +158,7 @@ export class CommentController {
     const data = await this.commentService.getMyCommentLike(userId, commentId);
     return {
       status: HttpStatus.OK,
-      messgae: '나의 댓글 좋아요 여부 조회에 성공했습니다.',
+      message: '나의 댓글 좋아요 여부 조회에 성공했습니다.',
       data: data,
     };
   }
@@ -214,7 +214,7 @@ export class CommentController {
     );
     return {
       status: HttpStatus.OK,
-      messgae: '나의 댓글 싫어요 여부 조회에 성공했습니다.',
+      message: '나의 댓글 싫어요 여부 조회에 성공했습니다.',
       data: data,
     };
   }

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -194,6 +194,7 @@ export class CommentService {
         postId: comment.postId,
         createdAt: comment.createdAt,
         updateAt: comment.updateAt,
+        nickname: comment.user.nickname,
         likes: comment.commentLikes.length,
         dislikes: comment.commentDislikes.length,
         recommentsCount

--- a/src/recomment/recomment.controller.ts
+++ b/src/recomment/recomment.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   ForbiddenException,
   HttpStatus,
+  Get,
 } from '@nestjs/common';
 import { RecommentService } from './recomment.service';
 import { CreateRecommentDto } from './dtos/create-recomment.dto';
@@ -20,15 +21,16 @@ import {
 import { LogIn } from 'src/decorators/log-in.decorator';
 import { User } from 'src/user/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
+import { COMMENT_MESSAGE } from 'src/constants/comment-message.constant';
 
-@UseGuards(AuthGuard('jwt'))
 @ApiTags('5. RECOMMENT API')
-@ApiBearerAuth()
 @Controller('comments')
 export class RecommentController {
   constructor(private readonly recommentService: RecommentService) {}
 
   /** 대댓글 생성 **/
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
   @ApiOperation({ summary: '1. 대댓글 생성 API' })
   @ApiResponse({ status: HttpStatus.CREATED })
   @Post(':commentId/recomments')
@@ -44,8 +46,23 @@ export class RecommentController {
     );
   }
 
+  /** 대댓글 목록 조회 **/
+  @ApiOperation({ summary: '2. 대댓글 목록 조회 API' })
+  @Get(':commentId/recomments')
+  async findAll(@Param('commentId') commentId: number) {
+    const data = await this.recommentService.findRecommentsById(commentId)
+
+    return {
+      status: HttpStatus.OK,
+      message: COMMENT_MESSAGE.COMMENT.READ.SUCCESS,
+      data
+    }
+  }
+
   /** 대댓글 수정 **/
-  @ApiOperation({ summary: '2. 대댓글 수정 API' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '3. 대댓글 수정 API' })
   @Patch(':commentId/recomments/:recommentId')
   async updateRecomment(
     @Param('commentId') commentId: number,
@@ -67,7 +84,9 @@ export class RecommentController {
   }
 
   /** 대댓글 삭제 **/
-  @ApiOperation({ summary: '3. 대댓글 삭제 API' })
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '4. 대댓글 삭제 API' })
   @Delete(':commentsId/recomments/:recommentId')
   async removeRecomment(
     @Param('commentId') commentId: number,

--- a/src/recomment/recomment.service.ts
+++ b/src/recomment/recomment.service.ts
@@ -80,6 +80,32 @@ export class RecommentService {
     return newRecomment;
   }
 
+  /** 대댓글 목록 조회 **/
+  async findRecommentsById(commentId:number) {
+    const recomments = await this.commentRepository.find({
+      where: { parentId: commentId},
+      relations: ['user', 'commentLikes', 'commentDislikes'],
+      select:{
+        user:{
+          nickname:true
+        }
+      }
+    }) 
+
+    return recomments.map(recomment => ({
+      id: recomment.id,
+      parentId: recomment.parentId,
+      content: recomment.content,
+      userId: recomment.userId,
+      nickname: recomment.user.nickname,
+      postId: recomment.postId,
+      createdAt: recomment.createdAt,
+      updateAt: recomment.updateAt,
+      likes: recomment.commentLikes.length,
+      dislikes: recomment.commentDislikes.length,
+    }));
+  }
+
   //대댓글 수정
   async updateRecomment(
     commentId: number,


### PR DESCRIPTION
## 📌 관련 이슈

closed #222 

## ✨ 과제 내용

 댓글 목록 조회 API 변경 : postId 받고 대댓글은 안가져오게. (parentId = NULL )
 GET (/api/posts/:postId/comments
 대댓글 목록 조회 API 추가 : commetId 받고 parentId : commentId 인 대댓글 시간 순으로 조회
 GET (/api/comments/:commentId/recomment)
 게시글 상세페이지 댓글만 불러오게 수정
 게시글 상세페이지 댓글 옆 더보기 버튼을 누르면 대댓글 조회
 기존 코드 삭제 : 댓글 목록 조회 API

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
