### PR TITLE
fix: 클릭모양 관련

### DIFF
--- a/front/html/alarm.html
+++ b/front/html/alarm.html
@@ -47,10 +47,10 @@
       </div>
 
       <div class="filter-container">
-        <button id="filter-button" onClick="readAllAlarm()">
+        <button id="filter-button" class="alarm-btn" onClick="readAllAlarm()">
           모두 읽음 처리 ✔️
         </button>
-        <button id="filter-button" onClick="deleteAllAlarm()">
+        <button id="filter-button" class="alarm-btn" onClick="deleteAllAlarm()">
           읽은 알람 모두 삭제 ❌
         </button>
       </div>

--- a/front/styles/alarm.css
+++ b/front/styles/alarm.css
@@ -47,6 +47,7 @@ button {
 
 .deleteAlarm {
   border: 0px;
+  cursor: pointer;
 }
 
 .deleteAlarm:hover {
@@ -55,6 +56,7 @@ button {
 
 .checkAlarm {
   border: 0px;
+  cursor: pointer;
 }
 
 .checkAlarm:hover {
@@ -72,9 +74,14 @@ button {
 
 .onClickAlarm {
   color: black;
+  cursor: pointer;
 }
 
 .onClickAlarm:hover {
   color: blue;
   font-weight: bold;
+}
+
+.alarm-btn {
+  cursor: pointer;
 }

--- a/front/styles/index.css
+++ b/front/styles/index.css
@@ -411,7 +411,6 @@ ul.point-rank-tabs li.current {
   flex-direction: row;
   overflow: hidden;
   height: 22px;
-  cursor: pointer;
 }
 
 /* 2-2-6-1. POINT RANK RANKING */


### PR DESCRIPTION
1. 미구현 기능은 호버시 클릭모양 뜨지 않게
2. 알람 페이지에서 클릭모양 안뜨는 부분 수정

## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
 closed #288 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->
- 미구현 기능은 호버시 클릭모양 뜨지 않게
- 알람 페이지에서 클릭모양 안뜨는 부분 수정

메인페이지에서
미구현 기능(포인트 랭킹에서 닉네임 호버시 커서가 클릭모양 되지 않도록)
호버시 클릭모양 뜨지 않게

(단, 해시태그의 경우 네이버 쇼핑몰 API 추가되면
연결시킬 예정이므로, 그대로 두었습니다!)

+) 알람페이지에서 버튼들 클릭모양 뜨도록 수정

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
