### PR TITLE
fix:삭제된컬럼 where절 삭제

### DIFF
--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -386,8 +386,7 @@ export class ChatService {
       select c.id as id, c.user_id as owner_id, c.title as title, c.img_url as img_url, d.count as count, c.created_at
       from (select a.id, a.user_id , a.title , b.img_url , b.created_at
       from chat_rooms a left join chat_Images b
-      on a.user_id = b.user_id
-      where a.is_deleted = FALSE) c join (select room_id , count(*) as count
+      on a.user_id = b.user_id) c join (select room_id , count(*) as count
       from chat_members
       group by room_id) d
       on c.id = d.room_id


### PR DESCRIPTION
## 📌 관련 이슈

#371 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- chatroom entity의 삭제된 컬럼 'is_delete' 가 where절에 조건으로 불러오는 쿼리에서 오류 수정
- is_deleted 조건 삭제

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
